### PR TITLE
Fix broken links and remove gone assignment

### DIFF
--- a/static/webprog.html
+++ b/static/webprog.html
@@ -252,28 +252,28 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/1-html_css/HTML-Syntax/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1-html_css/HTML-Syntax"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1%20HTML%20und%20CSS/Beispiele/HTML-Syntax"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Strukturgebende HTML-Elemente">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/1-html_css/Strukturgebende%20Elemente/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1-html_css/Strukturgebende%20Elemente"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1%20HTML%20und%20CSS/Beispiele/Strukturgebende%20Elemente"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Keyframe-Animationen">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/1-html_css/Keyframe%20Beispiel/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1-html_css/Keyframe%20Beispiel"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1%20HTML%20und%20CSS/Beispiele/Keyframe-Animationen"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Simpler Parallax-Effekt">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/1-html_css/Parallax-Effekt/parallax.html"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1-html_css/Parallax-Effekt"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1%20HTML%20und%20CSS/Beispiele/Parallax-Effekt"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -289,7 +289,7 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/1-html_css/npmjs.com/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1-html_css/npmjs.com"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1%20HTML%20und%20CSS/Aufgaben/npmjs.com"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -305,14 +305,14 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/1-html_css/Einfaches%20Layout/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1-html_css/Einfaches%20Layout/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1%20HTML%20und%20CSS/Aufgaben/Einfaches%20Layout/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Einfaches Layout">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/1-html_css/Einfaches%20Layout/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1-html_css/Einfaches%20Layout/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/1%20HTML%20und%20CSS/Aufgaben/Einfaches%20Layout/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
         </page-content>
@@ -373,7 +373,7 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Music%20App/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Music%20App"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Beispiele/Music%20App"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -381,14 +381,14 @@
             <wpvs-container>
                 <wpvs-material-card data-type="Fotos" data-name="Bilderpaket: Grid-Layout mit Bootstrap">
                     <material-meta data-label="Lizenz" data-value="CC-BY-4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Download" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Bootstrap-Aufgabe/Bilder"></material-link>
+                    <material-link data-icon="icon-git" data-label="Download" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/CSS-Grid%20mit%20Bootstrap/Bilder"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Grid-Layout mit Bootstrap">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Bootstrap-Aufgabe/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Bootstrap-Aufgabe/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/CSS-Grid%20mit%20Bootstrap/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -398,21 +398,21 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Gnome%203/Beschreibung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Gnome%203/Beschreibung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Gnome%203/Beschreibung"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Aufgabe: gnome.org mit Bootstrap">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Gnome%203/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Gnome%203/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Gnome%203/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: gnome.org mit Bootstrap">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Gnome%203/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Gnome%203/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Gnome%203/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -422,14 +422,14 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Media%20Query/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Media%20Query/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Media%20Query/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Media Query">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Media%20Query/L%C3%B6sung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Media%20Query/L%C3%B6sung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Media%20Query/L%C3%B6sung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -439,21 +439,21 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Mobile%20Bildergallerie/Beschreibung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Mobile%20Bildergallerie/Beschreibung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Mobile%20Bildergallerie/Beschreibung"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Aufgabe: Mobile Bildergallerie">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Mobile%20Bildergallerie/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Mobile%20Bildergallerie/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Mobile%20Bildergallerie/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Mobile Bildergallerie">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Mobile%20Bildergallerie/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Mobile%20Bildergallerie/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Mobile%20Bildergallerie/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -475,14 +475,14 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Mobile%20First/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Mobile%20First/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Mobile%20First/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Mobile First">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/2-responsive_webdesign/Mobile%20First/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2-responsive_webdesign/Mobile%20First/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/2%20Responsive%20Webdesign/Aufgaben/Mobile%20First/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
         </page-content>
@@ -597,34 +597,34 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Mini-Beispiel%20f%C3%BCr%20Event%20Listener/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Mini-Beispiel%20f%C3%BCr%20Event%20Listener"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Beispiele/Mini-Beispiel%20f%C3%BCr%20Event%20Listener"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Formulareingaben prüfen">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Formulareingaben%20pr%C3%BCfen/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Formulareingaben%20pr%C3%BCfen"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Beispiele/Formulareingaben%20pr%C3%BCfen"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Tabreiter umschalten">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Tabreiter%20umschalten/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Tabreiter%20umschalten"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Beispiele/Tabreiter%20umschalten"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Google Firebase">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Google%20Firebase/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Google%20Firebase"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Beispiele/Google%20Firebase"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Socketserver">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Socketserver"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Beispiele/Socketserver"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -634,21 +634,21 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Adressbuch/Beschreibung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Adressbuch/Beschreibung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Adressbuch/Beschreibung"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Aufgabe: Adressbuch">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Adressbuch/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Adressbuch/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Adressbuch/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Adressbuch">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Adressbuch/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Adressbuch/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Adressbuch/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -658,14 +658,14 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Einfache%20TODO-Liste/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Einfache%20TODO-Liste/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Einfache%20TODO-Liste/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Einfache TODO-Liste">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Einfache%20TODO-Liste/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Einfache%20TODO-Liste/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Einfache%20TODO-Liste/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -675,14 +675,14 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Erfassungsformular/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Erfassungsformular/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Erfassungsformular/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Erfassungsformular">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Erfassungsformular/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Erfassungsformular/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Erfassungsformular/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -692,14 +692,14 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Finde%20den%20Fehler/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Finde%20den%20Fehler/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Finde%20den%20Fehler/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Finde den Fehler">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Finde%20den%20Fehler/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Finde%20den%20Fehler/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Finde%20den%20Fehler/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -709,14 +709,14 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Gluecksrad/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Gluecksrad/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Gluecksrad/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Glücksrad">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Gluecksrad/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Gluecksrad/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Gluecksrad/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -726,14 +726,14 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Inhalte%20eines%20Arrays%20anzeigen/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Inhalte%20eines%20Arrays%20anzeigen/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Inhalte%20eines%20Arrays%20anzeigen/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Inhalte eines Arrays zeigen">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Inhalte%20eines%20Arrays%20anzeigen/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Inhalte%20eines%20Arrays%20anzeigen/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Inhalte%20eines%20Arrays%20anzeigen/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -742,21 +742,21 @@
                 <wpvs-material-card data-type="Musik und Playliste" data-name="Songpaket: Media Player">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Download" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Media%20Player/Songs"></material-link>
+                    <material-link data-icon="icon-git" data-label="Download" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Media%20Player/Songs"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Aufgabe: Media Player">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Media%20Player/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Media%20Player/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Media%20Player/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Media Player">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Media%20Player/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Media%20Player/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Media%20Player/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -766,14 +766,14 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Stoppuhr%20mit%20Closures/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Stoppuhr%20mit%20Closures/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Stoppuhr%20mit%20Closures/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Stoppuhr mit Closures">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Stoppuhr%20mit%20Closures/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Stoppuhr%20mit%20Closures/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Stoppuhr%20mit%20Closures/Loesung"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -783,20 +783,20 @@
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Grundstruktur%20einer%20Single%20Page%20App/Aufgabe/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Grundstruktur%20einer%20Single%20Page%20App/Aufgabe"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Grundstruktur%20einer%20Single%20Page%20App/Aufgabe"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Grundstruktur einer Single Page App">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
                     <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/3-javascript/Grundstruktur%20einer%20Single%20Page%20App/Loesung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Grundstruktur%20einer%20Single%20Page%20App/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Grundstruktur%20einer%20Single%20Page%20App/Loesung"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Grundstruktur einer Single Page App (mit Parcel Bundler)">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3-javascript/Grundstruktur%20einer%20Single%20Page%20App/Loesung%20(mit%20Parcel-Bundler)"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/3%20JavaScript/Aufgaben/Grundstruktur%20einer%20Single%20Page%20App/Loesung%20(mit%20Parcel-Bundler)"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
         </page-content>
@@ -844,31 +844,31 @@
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Minimales Servlet">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Minimales%20Servlet"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4%20Serverseite%20mit%20Java/Beispiele/Minimales%20Servlet"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Servletmethoden">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Servletmethoden"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4%20Serverseite%20mit%20Java/Beispiele/Servletmethoden"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Aufgabenliste per Servlet">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Aufgabenliste%20per%20Servlet"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4%20Serverseite%20mit%20Java/Beispiele/Aufgabenliste%20per%20Servlet"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Aufgabenliste per JSP">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Aufgabenliste%20per%20JSP"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4%20Serverseite%20mit%20Java/Beispiele/Aufgabenliste%20per%20JSP"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Beispiel: Eingebetteter Webserver">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Eingebetteter%20Webserver"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4%20Serverseite%20mit%20Java/Beispiele/Eingebetteter%20Webserver"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -877,13 +877,13 @@
                 <wpvs-material-card data-type="Quellcode" data-name="Aufgabe: Servlets, JSP, Templates">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Servlets%2C%20JSP%2C%20Templates%20(Aufgabe)"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4%20Serverseite%20mit%20Java/Aufgaben/Servlets%2C%20JSP%2C%20Templates%20(Aufgabe)"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Servlets, JSP, Templates">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Servlets%2C%20JSP%2C%20Templates%20(Loesung)"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4%20Serverseite%20mit%20Java/Aufgaben/Servlets%2C%20JSP%2C%20Templates%20(Loesung)"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
 
@@ -892,35 +892,13 @@
                 <wpvs-material-card data-type="Quellcode" data-name="Aufgabe: Formular-Servlet mit JSP">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Formular-Servlet%20mit%20JSP%20(Aufgabe)"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4%20Serverseite%20mit%20Java/Aufgaben/Formular-Servlet%20mit%20JSP%20(Aufgabe)"></material-link>
                 </wpvs-material-card>
 
                 <wpvs-material-card data-type="Quellcode" data-name="Lösung: Formular-Servlet mit JSP">
                     <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
                     <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Formular-Servlet%20mit%20JSP%20(Loesung)"></material-link>
-                </wpvs-material-card>
-            </wpvs-container>
-
-            <h5>Aufgabe: Comicsammlung</h5>
-            <wpvs-container>
-                <wpvs-material-card data-type="Aufgabenblatt" data-name="Aufgabe: Comicsammlung">
-                    <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
-                    <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-globe" data-label="Onlineansicht" data-href="https://www.wpvs.de/repo/webprog/quellcodes/4-server-java/Comicsammlung/Beschreibung/"></material-link>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Comicsammlung/Beschreibung"></material-link>
-                </wpvs-material-card>
-
-                <wpvs-material-card data-type="Quellcode" data-name="Aufgabe: Comicsammlung">
-                    <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
-                    <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Comicsammlung/Aufgabe"></material-link>
-                </wpvs-material-card>
-
-                <wpvs-material-card data-type="Quellcode" data-name="Lösung: Comicsammlung">
-                    <material-meta data-label="Sprache" data-value="Deutsch"></material-meta>
-                    <material-meta data-label="Lizenz" data-value="CC-BY 4.0"></material-meta>
-                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4-server-java/Comicsammlung/Loesung"></material-link>
+                    <material-link data-icon="icon-git" data-label="Quellcode" data-href="https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/tree/master/4%20Serverseite%20mit%20Java/Aufgaben/Formular-Servlet%20mit%20JSP%20(Loesung)"></material-link>
                 </wpvs-material-card>
             </wpvs-container>
         </page-content>


### PR DESCRIPTION
Fixes broken links caused by https://github.com/DennisSchulmeister/dhbwka-wwi-webprog-quellcodes/commit/04f20feda9ef897ad52bc61f996c7ea44b5a9ff5.

Also removes the "Comicsammlung" assignment as that seems to be gone. 



Links referencing https://www.wpvs.de/repo/webprog/quellcodes/* will probably also break once this repository gets deployed there. 